### PR TITLE
Release fixes for DtD metrics

### DIFF
--- a/jobs/dtd-metrics/src/configs/macro-categories.ts
+++ b/jobs/dtd-metrics/src/configs/macro-categories.ts
@@ -58,7 +58,7 @@ export const MACRO_CATEGORIES = [
   },
   {
     id: '7',
-    name: 'Regioni',
+    name: 'Regioni e Province Autonome',
     ipaCodes: ['L4999'],
   },
   {
@@ -87,3 +87,18 @@ export const MACRO_CATEGORIES = [
     ipaCodes: ['SAG', 'L37', 'S01', 'SA'],
   },
 ] as const
+
+export const MACRO_CATEGORIES_COUNTS = {
+  '1': 4201,
+  '2': 245,
+  '3': 8546,
+  '4': 102,
+  '5': 47,
+  '6': 22,
+  '7': 0,
+  '8': 53,
+  '9': 8367,
+  '10': 207,
+  '11': 89,
+  '12': 1128,
+} as const

--- a/jobs/dtd-metrics/src/configs/macro-categories.ts
+++ b/jobs/dtd-metrics/src/configs/macro-categories.ts
@@ -59,7 +59,7 @@ export const MACRO_CATEGORIES = [
   {
     id: '7',
     name: 'Regioni e Province Autonome',
-    ipaCodes: ['L4999'],
+    ipaCodes: ['L4'],
   },
   {
     id: '8',
@@ -95,10 +95,38 @@ export const MACRO_CATEGORIES_COUNTS = {
   '4': 102,
   '5': 47,
   '6': 22,
-  '7': 0,
-  '8': 53,
+  '7': 21, // 19 Regioni + 2 Province autonome (TN + BZ)
+  // Categoria IPA L4 meno i 21 enti in macrocategoria 7
+  // meno la Regione Trentino/Sudtirol che di fatto non esiste
+  '8': 53 - 21 - 1,
   '9': 8367,
   '10': 207,
   '11': 89,
   '12': 1128,
 } as const
+
+// Attenzione: la Regione Trentino (r_trenti) non va considerata,
+// si considerano le due province autonome Trento e Bolzano
+export const REGIONI_E_PROVINCE_AUTONOME: Array<string> = [
+  'p_bz',
+  'p_TN',
+  'r_abruzz',
+  'r_basili',
+  'r_campan',
+  'r_emiro',
+  'r_friuve',
+  'r_lazio',
+  'r_liguri',
+  'r_lombar',
+  'r_marche',
+  'r_molise',
+  'r_piemon',
+  'r_puglia',
+  'r_sardeg',
+  'r_sicili',
+  'r_toscan',
+  'r_umbria',
+  'r_vda',
+  'r_veneto',
+  'regcal',
+]

--- a/jobs/dtd-metrics/src/index.ts
+++ b/jobs/dtd-metrics/src/index.ts
@@ -66,7 +66,7 @@ try {
   const dtdFilesOutput = metricsOutputFormatter.getDtdMetricsFiles()
 
   if (env.PRODUCE_OUTPUT_JSON) {
-    writeFileSync('dtd-metrics.json', JSON.stringify(dashboardOuput, null, 2))
+    writeFileSync('dtd-metrics.json', JSON.stringify({ ...dashboardOuput, dataDiPubblicazione: new Date() }, null, 2))
   }
 
   for (const { filename, data } of dtdFilesOutput) {

--- a/jobs/dtd-metrics/src/metrics/onboarded-tenants-count.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/onboarded-tenants-count.metric.ts
@@ -7,7 +7,7 @@ export const getOnboardedTenantsCountMetric: MetricFactoryFn<'totaleEnti'> = (_r
   return OnboardedTenantsCountMetric.parse([
     getMetricData('Totale', globalStore),
     getMetricData('Comuni', globalStore),
-    getMetricData('Regioni', globalStore),
+    getMetricData('Regioni e Province Autonome', globalStore),
     getMetricData('Università e AFAM', globalStore),
   ])
 }

--- a/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
@@ -2,6 +2,7 @@ import { getMonthsAgoDate } from '../utils/helpers.utils.js'
 import { add } from 'date-fns'
 import { MetricFactoryFn } from '../services/metrics-producer.service.js'
 import { TenantOnboardingTrendMetric } from '../models/metrics.model.js'
+import { MACRO_CATEGORIES_COUNTS } from '../configs/macro-categories.js'
 
 export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamentoAdesioni'> = (
   _readModel,
@@ -40,7 +41,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
         { days: 5 },
         macroCategory.onboardedTenants.map((tenant) => tenant.onboardedAt)
       ),
-      totalCount: macroCategory.tenants.length,
+      totalCount: MACRO_CATEGORIES_COUNTS[macroCategory.id as keyof typeof MACRO_CATEGORIES_COUNTS],
       onboardedCount: macroCategory.onboardedTenants.length,
       startingDate: sixMonthsAgoDate,
     })),
@@ -52,7 +53,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
         { days: 10 },
         macroCategory.onboardedTenants.map((tenant) => tenant.onboardedAt)
       ),
-      totalCount: macroCategory.tenants.length,
+      totalCount: MACRO_CATEGORIES_COUNTS[macroCategory.id as keyof typeof MACRO_CATEGORIES_COUNTS],
       onboardedCount: macroCategory.onboardedTenants.length,
       startingDate: twelveMonthsAgoDate,
     })),
@@ -64,7 +65,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
         { months: 1 },
         macroCategory.onboardedTenants.map((tenant) => tenant.onboardedAt)
       ),
-      totalCount: macroCategory.tenants.length,
+      totalCount: MACRO_CATEGORIES_COUNTS[macroCategory.id as keyof typeof MACRO_CATEGORIES_COUNTS],
       onboardedCount: macroCategory.onboardedTenants.length,
       startingDate: oldestTenantDate,
     })),

--- a/jobs/dtd-metrics/src/models/macro-categories.model.ts
+++ b/jobs/dtd-metrics/src/models/macro-categories.model.ts
@@ -13,6 +13,7 @@ export const MacroCategoryTenant = z.object({
   name: z.string(),
   macroCategoryId: z.string(),
   onboardedAt: z.coerce.date().optional(),
+  'externalId.value': z.string().optional(),
 })
 
 export const MacroCategoryOnboardedTenant = MacroCategoryTenant.extend({

--- a/jobs/dtd-metrics/src/services/global-store.service.ts
+++ b/jobs/dtd-metrics/src/services/global-store.service.ts
@@ -100,12 +100,14 @@ export class GlobalStoreService {
         .map((attribute) => ({ ...attribute, macroCategoryId: macroCategory.id }))
 
       // Get tenants that have at least one attribute of the macro category
+      // and are not AO/UOO
       const macroCategoryTenants = await readModel.tenants
         .find(
           {
             'data.attributes': {
               $elemMatch: { id: { $in: macroCategoryAttributes.map((a) => a.id) } },
             },
+            'data.subUnitType': { $exists: false },
           },
           {
             projection: {

--- a/jobs/dtd-metrics/src/services/opendata-rdf-generator.service.ts
+++ b/jobs/dtd-metrics/src/services/opendata-rdf-generator.service.ts
@@ -42,9 +42,9 @@ const SKOS_CONCEPT = [
 ] as const satisfies ReadonlyArray<SkosConcept>
 
 const ORGANIZATION = {
-  name: 'PagoPA S.p.A.',
+  name: 'PCM – Dipartimento per la trasformazione digitale',
   email: undefined,
-  url: CHARTS_PAGE,
+  url: 'https://innovazione.gov.it',
 } as const satisfies Organization
 
 /**
@@ -62,8 +62,10 @@ type MetricFile = {
   filename: string
   title: string
   description: string
-  rightsHolder: string
+  rightsHolderName: string
+  rightsHolderCode: string
   publisherName: string
+  publisherCode: string
   keywords: ReadonlyArray<string>
   modified: string // yyyy-mm-gg
   issued: string // yyyy-mm-gg
@@ -77,9 +79,11 @@ const METRICS_FILES = [
     filename: getFilename('entiErogatoriDiEService'),
     title: 'Enti erogatori di e-service',
     description: 'Numero di e-service pubblicati suddivisi per categorie di enti erogatori',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -89,9 +93,11 @@ const METRICS_FILES = [
     title: 'E-service con più enti abilitati',
     description:
       'I 10 e-service con più enti abilitati, filtrabili per ente erogatore e categoria di ente fruitore (ultimi sei mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -101,9 +107,11 @@ const METRICS_FILES = [
     title: 'E-service con più enti abilitati',
     description:
       'I 10 e-service con più enti abilitati, filtrabili per ente erogatore e categoria di ente fruitore (ultimi dodici mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -113,9 +121,11 @@ const METRICS_FILES = [
     title: 'E-service con più enti abilitati',
     description:
       'I 10 e-service con più enti abilitati, filtrabili per ente erogatore e categoria di ente fruitore (dall’inizio del servizio)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -124,9 +134,11 @@ const METRICS_FILES = [
     filename: getFilename('totaleEnti'),
     title: 'Totale enti e suddivisione per macro-categorie',
     description: 'Il totale degli enti che hanno aderito a PDND Interoperabilità',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -135,9 +147,11 @@ const METRICS_FILES = [
     filename: getFilename('eservicePubblicati'),
     title: 'E-service pubblicati',
     description: "Numero di e-service pubblicati e variazione nell'ultimo mese",
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -147,9 +161,11 @@ const METRICS_FILES = [
     title: 'Distribuzione degli enti per attività',
     description:
       'Numero di: enti erogatori che mettono a disposizione e-service; enti fruitori che li utilizzano; enti sia erogatori che fruitori; enti che effettuano solo l’accesso alla piattaforma',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -158,9 +174,11 @@ const METRICS_FILES = [
     filename: getFilename('statoDiCompletamentoAdesioniLastSixMonths'),
     title: 'Stato di completamento delle adesioni per categoria di ente pubblico',
     description: 'Percentuale di adesione degli enti sul totale della categoria (ultimi sei mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -169,9 +187,11 @@ const METRICS_FILES = [
     filename: getFilename('statoDiCompletamentoAdesioniLastTwelveMonths'),
     title: 'Stato di completamento delle adesioni per categoria di ente pubblico',
     description: 'Percentuale di adesione degli enti sul totale della categoria (ultimi dodici mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -180,9 +200,11 @@ const METRICS_FILES = [
     filename: getFilename('statoDiCompletamentoAdesioniFromTheBeginning'),
     title: 'Stato di completamento delle adesioni per categoria di ente pubblico',
     description: 'Percentuale di adesione degli enti sul totale della categoria (dall’inizio del servizio)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -191,9 +213,11 @@ const METRICS_FILES = [
     filename: getFilename('entiChePubblicanoPiuEServiceLastSixMonths'),
     title: 'Enti che pubblicano più e-service',
     description: 'I 10 enti erogatori con più e-service pubblicati (ultimi sei mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -202,9 +226,11 @@ const METRICS_FILES = [
     filename: getFilename('entiChePubblicanoPiuEServiceLastTwelveMonths'),
     title: 'Enti che pubblicano più e-service',
     description: 'I 10 enti erogatori con più e-service pubblicati (ultimi dodici mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -213,9 +239,11 @@ const METRICS_FILES = [
     filename: getFilename('entiChePubblicanoPiuEServiceFromTheBeginning'),
     title: 'Enti che pubblicano più e-service',
     description: 'I 10 enti erogatori con più e-service pubblicati (dall’inizio del servizio)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -224,9 +252,11 @@ const METRICS_FILES = [
     filename: getFilename('entiErogatoriEdEntiAbilitatiAllaFruizioneLastSixMonths'),
     title: 'Enti erogatori ed enti abilitati alla fruizione (ultimi sei mesi)',
     description: 'I 10 enti erogatori che hanno abilitato più enti fruitori (ultimi sei mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -235,9 +265,11 @@ const METRICS_FILES = [
     filename: getFilename('entiErogatoriEdEntiAbilitatiAllaFruizioneLastTwelveMonths'),
     title: 'Enti erogatori ed enti abilitati alla fruizione',
     description: 'I 10 enti erogatori che hanno abilitato più enti fruitori (ultimi dodici mesi)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -246,9 +278,11 @@ const METRICS_FILES = [
     filename: getFilename('entiErogatoriEdEntiAbilitatiAllaFruizioneFromTheBeginning'),
     title: 'Enti erogatori ed enti abilitati alla fruizione',
     description: 'I 10 enti erogatori che hanno abilitato più enti fruitori (dall’inizio del servizio)',
-    rightsHolder: 'Dipartimento per la trasformazione digitale',
+    rightsHolderName: 'PCM - Dipartimento per la trasformazione digitale',
+    rightsHolderCode: 'pcm',
     publisherName: 'PagoPA S.p.A.',
-    keywords: ['PDND'],
+    publisherCode: '5N2TR557',
+    keywords: ['PDND', 'API', 'PNRR', 'Interoperabilità'],
     modified: TODAY_DATE,
     issued: TODAY_DATE,
   },
@@ -302,12 +336,23 @@ export class MetricsOpenDataRdfGenerator {
   }
 
   private produceRDFDataset(metricFile: MetricFile): string {
-    const { filename, title, description, rightsHolder, publisherName, modified, issued, keywords } = metricFile
+    const {
+      filename,
+      title,
+      description,
+      rightsHolderName,
+      rightsHolderCode,
+      publisherName,
+      publisherCode,
+      modified,
+      issued,
+      keywords,
+    } = metricFile
 
     return `
 <dcatapit:Dataset rdf:about="${GITHUB_REPO_URL}/${filename}.csv">
   <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-  <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/SOCI"/>
+  <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/GOVE"/>
   <dct:license/>
   <dct:title>${title}</dct:title>
   <dct:landingpage>${GITHUB_REPO_URL}/${filename}.csv</dct:landingpage>
@@ -316,14 +361,14 @@ export class MetricsOpenDataRdfGenerator {
   <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/DAILY"/>
   <dcat:contactPoint rdf:resource="${CHARTS_PAGE}"/>
   <dct:rightsHolder>
-    <dcatapit:Agent rdf:about="mint">
+    <dcatapit:Agent rdf:about="${rightsHolderCode}">
       <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
       <dct:identifier>mint</dct:identifier>
-      <foaf:name>${rightsHolder}</foaf:name>
+      <foaf:name>${rightsHolderName}</foaf:name>
     </dcatapit:Agent>
   </dct:rightsHolder>
   <dct:publisher>
-    <dcatapit:Agent rdf:nodeID="Nd117aa7f2e7b47fb9481d4a8aca59c7d">
+    <dcatapit:Agent rdf:about="${publisherCode}">
       <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
       <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
       <dct:identifier>mint</dct:identifier>


### PR DESCRIPTION
In this (ugly PR):
- updated some data for the metadata file that goes into the open data repo
- removed AO/UOO from being counted among the onboarded Tenants
- added a publish date for the .json that goes to our dashboard charts
- temporary patch: added a manual count of IPA categories parties. We cannot do this on our Tenants read model
- added an ugly fix so that all regions but Trentino plus Bolzano and Trento are counted as a "Regioni e Province Autonome" macrocategory, while all other Tenants that have IPA category L4 are categorized as "Consorzi e associazioni regionali". This distinction will need to be addressed in the new version of the IPA Catalog
- renamed the "Regioni" macrocategory to "Regioni e Province Autonome"

Sorry for mashing them together, please see individual commits for easier evaluation