### PR TITLE
Added publish date to dashboard output json

### DIFF
--- a/jobs/dtd-metrics/src/index.ts
+++ b/jobs/dtd-metrics/src/index.ts
@@ -62,11 +62,11 @@ try {
 
   const metricsOutputFormatter = new MetricsOutputFormatterService(metrics)
 
-  const dashboardOuput = metricsOutputFormatter.getMetricsDashboardData()
+  const dashboardOuput = { ...metricsOutputFormatter.getMetricsDashboardData(), dataDiPubblicazione: new Date() }
   const dtdFilesOutput = metricsOutputFormatter.getDtdMetricsFiles()
 
   if (env.PRODUCE_OUTPUT_JSON) {
-    writeFileSync('dtd-metrics.json', JSON.stringify({ ...dashboardOuput, dataDiPubblicazione: new Date() }, null, 2))
+    writeFileSync('dtd-metrics.json', JSON.stringify(dashboardOuput, null, 2))
   }
 
   for (const { filename, data } of dtdFilesOutput) {


### PR DESCRIPTION
Publish date was mistakenly added only to JSON generated for local development. It should also be available on the JSON that is sent for displaying data on the Interop landing page metrics page