### PR TITLE
PIN-4390: Fix time series in `tenant-onboarding-trend` metric

### DIFF
--- a/jobs/dtd-metrics/src/configs/macro-categories.ts
+++ b/jobs/dtd-metrics/src/configs/macro-categories.ts
@@ -30,80 +30,77 @@ export const MACRO_CATEGORIES = [
       'L38',
       'L31',
     ],
+    totalTenantsCount: 4201,
   },
   {
     id: '2',
     name: 'Aziende Ospedaliere e ASL',
     ipaCodes: ['L8', 'L22', 'L7'],
+    totalTenantsCount: 245,
   },
   {
     id: '3',
     name: 'Comuni',
     ipaCodes: ['L18', 'L6'],
+    totalTenantsCount: 8546,
   },
   {
     id: '4',
     name: 'Province e Città Metropolitane',
     ipaCodes: ['L5', 'L45'],
+    totalTenantsCount: 102,
   },
   {
     id: '5',
     name: 'Pubbliche Amministrazioni Centrali',
     ipaCodes: ['C10', 'C5', 'C11', 'C1', 'C2'],
+    totalTenantsCount: 47,
   },
   {
     id: '6',
     name: 'Enti Nazionali di Previdenza ed Assistenza Sociale',
     ipaCodes: ['C16', 'C17'],
+    totalTenantsCount: 22,
   },
   {
     id: '7',
     name: 'Regioni e Province Autonome',
     ipaCodes: ['L4'],
+    totalTenantsCount: 21, // 19 Regioni + 2 Province autonome (TN + BZ)
   },
   {
     id: '8',
     name: 'Consorzi e associazioni regionali',
     ipaCodes: ['L4'],
+    // Categoria IPA L4 meno i 21 enti in macrocategoria 7
+    // meno la Regione Trentino/Sudtirol che di fatto non esiste
+    totalTenantsCount: 53 - 21 - 1,
   },
   {
     id: '9',
     name: 'Scuole',
     ipaCodes: ['L33'],
+    totalTenantsCount: 8367,
   },
   {
     id: '10',
     name: 'Università e AFAM',
     ipaCodes: ['L17', 'L15', 'L43'],
+    totalTenantsCount: 207,
   },
   {
     id: '11',
     name: 'Istituti di Ricerca',
     ipaCodes: ['C8', 'C12', 'L28'],
+    totalTenantsCount: 89,
   },
   {
     id: '12',
     name: 'Stazioni Appaltanti e Gestori di pubblici servizi',
     ipaCodes: ['SAG', 'L37', 'S01', 'SA'],
+    totalTenantsCount: 1128,
   },
 ] as const
-
-export const MACRO_CATEGORIES_COUNTS = {
-  '1': 4201,
-  '2': 245,
-  '3': 8546,
-  '4': 102,
-  '5': 47,
-  '6': 22,
-  '7': 21, // 19 Regioni + 2 Province autonome (TN + BZ)
-  // Categoria IPA L4 meno i 21 enti in macrocategoria 7
-  // meno la Regione Trentino/Sudtirol che di fatto non esiste
-  '8': 53 - 21 - 1,
-  '9': 8367,
-  '10': 207,
-  '11': 89,
-  '12': 1128,
-} as const
 
 // Attenzione: la Regione Trentino (r_trenti) non va considerata,
 // si considerano le due province autonome Trento e Bolzano

--- a/jobs/dtd-metrics/src/models/macro-categories.model.ts
+++ b/jobs/dtd-metrics/src/models/macro-categories.model.ts
@@ -31,6 +31,7 @@ export const MacroCategory = z.object({
   id: z.string(),
   name: z.string(),
   ipaCodes: z.array(z.string()),
+  totalTenantsCount: z.number(),
   attributes: z.array(MacroCategoryAttribute),
   tenants: z.array(MacroCategoryTenant),
   onboardedTenants: z.array(MacroCategoryOnboardedTenant),

--- a/jobs/dtd-metrics/src/services/global-store.service.ts
+++ b/jobs/dtd-metrics/src/services/global-store.service.ts
@@ -196,7 +196,7 @@ function assignMacrocategoryId<TTenant extends { externalId?: { value: string } 
     throw new Error('Macro categories Regioni e Province Autonome or Consorzi e associazioni regionali not found')
 
   // If we are in a safe macrocategory, just assign it
-  if (macroCategoryId !== regioniEProvinceAutonomeId || macroCategoryId !== consorziEAssociazioniRegionaliId)
+  if (macroCategoryId !== regioniEProvinceAutonomeId && macroCategoryId !== consorziEAssociazioniRegionaliId)
     return macroCategoryId
   // If the Tenant is a Region or an Autonomy, assign the "Regioni e Province Autonome" macrocategory id
   if (REGIONI_E_PROVINCE_AUTONOME.includes(tenant.externalId?.value ?? '')) return regioniEProvinceAutonomeId

--- a/jobs/dtd-metrics/src/services/global-store.service.ts
+++ b/jobs/dtd-metrics/src/services/global-store.service.ts
@@ -92,16 +92,11 @@ export class GlobalStoreService {
       .map(({ data }) => Attribute.pick({ id: true, code: true }).parse(data))
       .toArray()
 
+    // Get all the tenants that have at least one of the attributes found before
     const tenants = await readModel.tenants
       .find(
         {
-          'data.attributes': {
-            $elemMatch: {
-              id: {
-                $in: attributes.map(({ id }) => id),
-              },
-            },
-          },
+          'data.attributes.id': { $in: attributes.map(({ id }) => id) },
           'data.subUnitType': { $exists: false },
           'data.onboardedAt': { $exists: true },
         },
@@ -127,27 +122,29 @@ export class GlobalStoreService {
       .toArray()
 
     const enrichMacroCategory = (macroCategory: (typeof MACRO_CATEGORIES)[number]): MacroCategory => {
+      // Get all the attributes related to the macro category
       const macroCategoryAttributes = attributes
         .filter(({ code }) => (macroCategory.ipaCodes as ReadonlyArray<string | undefined>).includes(code))
         .map((attribute) => ({ ...attribute, macroCategoryId: macroCategory.id }))
 
+      // Get all the tenants that have at least one of the macro category attributes
       const macroCategoryTenants = tenants.reduce<Array<GlobalStoreTenant>>((acc, next) => {
+        // If the tenant has no attributes or the attributes they have are revoked, skip it
         const isTenantInMacroCategory = next.attributes.some(
           ({ id, revocationTimestamp }) => macroCategoryAttributes.some((a) => a.id === id) && !revocationTimestamp
         )
-
         if (!isTenantInMacroCategory) return acc
 
+        // Get the macro category id for the tenant
         const macroCategoryId = assignMacrocategoryId(next, macroCategory.id)
+        // If the macro category id is not the same as the current macro category, skip it
         if (macroCategoryId !== macroCategory.id) return acc
 
         return [...acc, { ...next, macroCategoryId }]
       }, [])
 
       return MacroCategory.parse({
-        id: macroCategory.id,
-        name: macroCategory.name,
-        ipaCodes: macroCategory.ipaCodes,
+        ...macroCategory,
         attributes: macroCategoryAttributes,
         tenants: macroCategoryTenants,
         onboardedTenants: getOnboardedTenants(macroCategoryTenants),
@@ -158,9 +155,12 @@ export class GlobalStoreService {
     const macroCategories = MACRO_CATEGORIES.map(enrichMacroCategory)
     const macroCategoryTenants = macroCategories.flatMap(({ tenants }) => tenants)
 
-    if (tenants.length !== macroCategoryTenants.length) throw new Error('Tenants count mismatch')
+    if (tenants.length !== macroCategoryTenants.length) {
+      throw new Error(
+        `Tenants length (${tenants.length}) and macro category tenants length (${macroCategoryTenants.length}) mismatch`
+      )
+    }
     if (config?.cache) this.cacheInitializationData({ macroCategories, tenants: macroCategoryTenants })
-
     return new GlobalStoreService(macroCategoryTenants, macroCategories)
   }
 
@@ -187,10 +187,19 @@ function assignMacrocategoryId<TTenant extends { externalId?: { value: string } 
   tenant: TTenant,
   macroCategoryId: MacroCategory['id']
 ): MacroCategory['id'] {
+  const regioniEProvinceAutonomeId = MACRO_CATEGORIES.find(({ name }) => name === 'Regioni e Province Autonome')?.id
+  const consorziEAssociazioniRegionaliId = MACRO_CATEGORIES.find(
+    ({ name }) => name === 'Consorzi e associazioni regionali'
+  )?.id
+
+  if (!regioniEProvinceAutonomeId || !consorziEAssociazioniRegionaliId)
+    throw new Error('Macro categories Regioni e Province Autonome or Consorzi e associazioni regionali not found')
+
   // If we are in a safe macrocategory, just assign it
-  if (!['7', '8'].includes(macroCategoryId)) return macroCategoryId
+  if (macroCategoryId !== regioniEProvinceAutonomeId || macroCategoryId !== consorziEAssociazioniRegionaliId)
+    return macroCategoryId
   // If the Tenant is a Region or an Autonomy, assign the "Regioni e Province Autonome" macrocategory id
-  if (REGIONI_E_PROVINCE_AUTONOME.includes(tenant.externalId?.value ?? '')) return '7'
+  if (REGIONI_E_PROVINCE_AUTONOME.includes(tenant.externalId?.value ?? '')) return regioniEProvinceAutonomeId
   // Assign the "Consorzi e associazioni regionali" to all others
-  return '8'
+  return consorziEAssociazioniRegionaliId
 }

--- a/jobs/dtd-metrics/src/services/opendata-rdf-generator.service.ts
+++ b/jobs/dtd-metrics/src/services/opendata-rdf-generator.service.ts
@@ -42,7 +42,7 @@ const SKOS_CONCEPT = [
 ] as const satisfies ReadonlyArray<SkosConcept>
 
 const ORGANIZATION = {
-  name: 'PCM – Dipartimento per la trasformazione digitale',
+  name: 'PCM - Dipartimento per la trasformazione digitale',
   email: 'pdnd-interop-assistenza-opendata@pagopa.it',
   url: 'https://innovazione.gov.it',
 } as const satisfies Organization
@@ -290,8 +290,7 @@ const METRICS_FILES = [
 
 export class MetricsOpenDataRdfGenerator {
   public produceOpenDataRDF(): string {
-    return `
-<?xml version="1.0" encoding="utf-8"?>
+    return `<?xml version="1.0" encoding="utf-8"?>
   <rdf:RDF xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:hydra="http://www.w3.org/ns/hydra/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcatapit="http://dati.gov.it/onto/dcatapit#" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gsp="http://www.opengis.net/ont/geosparql#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
   ${this.produceRDFCatalog()}
   ${METRICS_FILES.map(this.produceRDFDataset).join('\n')}


### PR DESCRIPTION
This PR changes the way the timeseries are generated in the `tenant-onboarding-trend` metric. 
The current date is now included in the generated metric.

