### PR TITLE
PIN-4421: Fix `tenant-onboarding-trend` metric

### DIFF
--- a/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
@@ -18,21 +18,8 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
     return oldestDate
   }, new Date())
 
-  // Filter out tenants that are older than 6 months
-  const sixMonthsAgoData = globalStore.macroCategories.map((macroCategory) => ({
-    ...macroCategory,
-    onboardedTenants: macroCategory.onboardedTenants.filter(({ onboardedAt }) => onboardedAt > sixMonthsAgoDate),
-  }))
-  // Filter out tenants that are older than 12 months
-  const twelveMonthsAgoData = globalStore.macroCategories.map((macroCategory) => ({
-    ...macroCategory,
-    onboardedTenants: macroCategory.onboardedTenants.filter(({ onboardedAt }) => onboardedAt > twelveMonthsAgoDate),
-  }))
-
-  const fromTheBeginningData = globalStore.macroCategories
-
   const result = TenantOnboardingTrendMetric.parse({
-    lastSixMonths: sixMonthsAgoData.map((macroCategory) => ({
+    lastSixMonths: globalStore.macroCategories.map((macroCategory) => ({
       id: macroCategory.id,
       name: macroCategory.name,
       data: toTimeseriesSequenceData({
@@ -44,7 +31,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
       onboardedCount: macroCategory.onboardedTenants.length,
       startingDate: sixMonthsAgoDate,
     })),
-    lastTwelveMonths: twelveMonthsAgoData.map((macroCategory) => ({
+    lastTwelveMonths: globalStore.macroCategories.map((macroCategory) => ({
       id: macroCategory.id,
       name: macroCategory.name,
       data: toTimeseriesSequenceData({
@@ -56,7 +43,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
       onboardedCount: macroCategory.onboardedTenants.length,
       startingDate: twelveMonthsAgoDate,
     })),
-    fromTheBeginning: fromTheBeginningData.map((macroCategory) => ({
+    fromTheBeginning: globalStore.macroCategories.map((macroCategory) => ({
       id: macroCategory.id,
       name: macroCategory.name,
       data: toTimeseriesSequenceData({


### PR DESCRIPTION
To calculate a given timeserie for a specific period of time there was a filter that filtered all the data for that specific period.  For example, to calculate the timeseries for the six month ago data, the data given to the function that does the timeseries was being filtered, removing the data older than six months ago. That filter is removed in this PR