### PR TITLE
PIN-4427: Removed time from timeseries dates

### DIFF
--- a/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
@@ -17,6 +17,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
     }
     return oldestDate
   }, new Date())
+  oldestTenantDate.setHours(0, 0, 0, 0)
 
   const result = TenantOnboardingTrendMetric.parse({
     lastSixMonths: globalStore.macroCategories.map((macroCategory) => ({
@@ -76,12 +77,15 @@ function toTimeseriesSequenceData({
   data: Array<Date>
 }): Array<{ date: Date; count: number }> {
   let currentDate = new Date()
+  currentDate.setHours(0, 0, 0, 0)
+
   let currentCount: number = data.length
   const timeseriesData: Array<{ date: Date; count: number }> = [{ date: currentDate, count: currentCount }]
 
   while (oldestDate < currentDate) {
     // Jump to the next date
     currentDate = sub(currentDate, jump)
+    currentDate.setHours(0, 0, 0, 0)
     // Count the number of dates that are less than or equal to the current date, and add it to the timeseries data
     currentCount = data.filter((date) => date <= currentDate).length
 

--- a/jobs/dtd-metrics/src/utils/helpers.utils.ts
+++ b/jobs/dtd-metrics/src/utils/helpers.utils.ts
@@ -4,7 +4,9 @@ import { sub } from 'date-fns'
 import { json2csv as _json2csv } from 'json-2-csv'
 
 export function getMonthsAgoDate(numMonths: number): Date {
-  return sub(new Date(), { months: numMonths })
+  const result = sub(new Date(), { months: numMonths })
+  result.setHours(0, 0, 0, 0)
+  return result
 }
 
 export function getVariationPercentage(current: number, total: number): number {


### PR DESCRIPTION
This PR removes hours, minutes, seconds and milliseconds from timeseries related dates in order to facilitate date comparisons FE side.