### PR TITLE
PIN-4443: Updated `globalStore` and `onboarded-tenant-count` metric

### DIFF
--- a/jobs/dtd-metrics/src/metrics/__tests__/onboarded-tenants-count.metric.test.ts
+++ b/jobs/dtd-metrics/src/metrics/__tests__/onboarded-tenants-count.metric.test.ts
@@ -17,19 +17,24 @@ describe('getOnboardedTenantsCountMetric', () => {
           selfcareId: randomUUID(),
           onboardedAt: getMonthsAgoDate(6),
           attributes: [{ id: comuniAttributeId }],
+          externalId: { origin: 'IPA' },
         }),
         attributes: [{ id: comuniAttributeId }],
       },
       10
     )
 
-    const _notOnboardedTenant = getTenantMock<Tenant>({ attributes: [{ id: comuniAttributeId }] })
+    const _notOnboardedTenant = getTenantMock<Tenant>({
+      attributes: [{ id: comuniAttributeId }],
+      externalId: { origin: 'IPA' },
+    })
     delete _notOnboardedTenant.onboardedAt
     const _notOnboardedTenants = repeatObjInArray({ data: _notOnboardedTenant }, 10)
 
     const _onboardedLastMonthTenant = getTenantMock({
       onboardedAt: new Date(),
       attributes: [{ id: comuniAttributeId }],
+      externalId: { origin: 'IPA' },
     })
     const _onboardedLastMonthTenants = repeatObjInArray({ data: _onboardedLastMonthTenant }, 2)
 

--- a/jobs/dtd-metrics/src/metrics/onboarded-tenants-count.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/onboarded-tenants-count.metric.ts
@@ -5,7 +5,7 @@ import { getMonthsAgoDate, getVariationPercentage } from '../utils/helpers.utils
 
 export const getOnboardedTenantsCountMetric: MetricFactoryFn<'totaleEnti'> = (_readModel, globalStore) => {
   return OnboardedTenantsCountMetric.parse([
-    getMetricData('Totale', globalStore),
+    getMetricData('Totale enti', globalStore),
     getMetricData('Pubblici', globalStore),
     getMetricData('Privati', globalStore),
     getMetricData('Comuni', globalStore),
@@ -21,7 +21,7 @@ function getMetricData(
   let tenants: Array<{ onboardedAt: Date }>
 
   switch (name) {
-    case 'Totale':
+    case 'Totale enti':
       tenants = [...globalStore.tenants, ...globalStore.notIPATenants]
       break
     case 'Pubblici':

--- a/jobs/dtd-metrics/src/metrics/tenant-distribution.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/tenant-distribution.metric.ts
@@ -71,7 +71,7 @@ export const getTenantDistributionMetric: MetricFactoryFn<'distribuzioneDegliEnt
     else onlyAccess.count++
   }
 
-  globalStore.onboardedTenants.forEach(resolveTenantDistribution)
+  globalStore.tenants.forEach(resolveTenantDistribution)
 
   return [onlyConsumers, onlyProducers, bothConsumersAndProducers, onlyAccess]
 }

--- a/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/tenant-onboarding-trend.metric.ts
@@ -11,7 +11,7 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
   const twelveMonthsAgoDate = getMonthsAgoDate(12)
 
   // Get the oldest tenant date, which will be used as the starting point for the timeseries
-  const oldestTenantDate = globalStore.onboardedTenants.reduce((oldestDate, tenant) => {
+  const oldestTenantDate = globalStore.tenants.reduce((oldestDate, tenant) => {
     if (tenant.onboardedAt < oldestDate) {
       return tenant.onboardedAt
     }
@@ -25,10 +25,10 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
       data: toTimeseriesSequenceData({
         oldestDate: sixMonthsAgoDate,
         jump: { days: 5 },
-        data: macroCategory.onboardedTenants.map((tenant) => tenant.onboardedAt),
+        data: macroCategory.tenants.map((tenant) => tenant.onboardedAt),
       }),
       totalCount: macroCategory.totalTenantsCount,
-      onboardedCount: macroCategory.onboardedTenants.length,
+      onboardedCount: macroCategory.tenants.length,
       startingDate: sixMonthsAgoDate,
     })),
     lastTwelveMonths: globalStore.macroCategories.map((macroCategory) => ({
@@ -37,10 +37,10 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
       data: toTimeseriesSequenceData({
         oldestDate: twelveMonthsAgoDate,
         jump: { days: 10 },
-        data: macroCategory.onboardedTenants.map((tenant) => tenant.onboardedAt),
+        data: macroCategory.tenants.map((tenant) => tenant.onboardedAt),
       }),
       totalCount: macroCategory.totalTenantsCount,
-      onboardedCount: macroCategory.onboardedTenants.length,
+      onboardedCount: macroCategory.tenants.length,
       startingDate: twelveMonthsAgoDate,
     })),
     fromTheBeginning: globalStore.macroCategories.map((macroCategory) => ({
@@ -49,10 +49,10 @@ export const getTenantOnboardingTrendMetric: MetricFactoryFn<'statoDiCompletamen
       data: toTimeseriesSequenceData({
         oldestDate: oldestTenantDate,
         jump: { months: 1 },
-        data: macroCategory.onboardedTenants.map((tenant) => tenant.onboardedAt),
+        data: macroCategory.tenants.map((tenant) => tenant.onboardedAt),
       }),
       totalCount: macroCategory.totalTenantsCount,
-      onboardedCount: macroCategory.onboardedTenants.length,
+      onboardedCount: macroCategory.tenants.length,
       startingDate: oldestTenantDate,
     })),
   })

--- a/jobs/dtd-metrics/src/models/macro-categories.model.ts
+++ b/jobs/dtd-metrics/src/models/macro-categories.model.ts
@@ -12,20 +12,14 @@ export const MacroCategoryTenant = z.object({
   id: z.string(),
   name: z.string(),
   macroCategoryId: z.string(),
-  onboardedAt: z.coerce.date().optional(),
+  onboardedAt: z.coerce.date(),
   externalId: z
     .object({
       value: z.string(),
     })
     .optional(),
 })
-
-export const MacroCategoryOnboardedTenant = MacroCategoryTenant.extend({
-  onboardedAt: z.coerce.date(),
-})
-
 export type MacroCategoryTenant = z.infer<typeof MacroCategoryTenant>
-export type MacroCategoryOnboardedTenant = z.infer<typeof MacroCategoryOnboardedTenant>
 
 export const MacroCategory = z.object({
   id: z.string(),
@@ -34,7 +28,6 @@ export const MacroCategory = z.object({
   totalTenantsCount: z.number(),
   attributes: z.array(MacroCategoryAttribute),
   tenants: z.array(MacroCategoryTenant),
-  onboardedTenants: z.array(MacroCategoryOnboardedTenant),
   tenantsIds: z.array(z.string()),
 })
 

--- a/jobs/dtd-metrics/src/models/metrics.model.ts
+++ b/jobs/dtd-metrics/src/models/metrics.model.ts
@@ -86,7 +86,7 @@ export type TenantOnboardingTrendMetric = z.infer<typeof TenantOnboardingTrendMe
 
 export const OnboardedTenantsCountMetric = z.tuple([
   z.object({
-    name: z.literal('Totale'),
+    name: z.literal('Totale enti'),
     totalCount: z.number(),
     lastMonthCount: z.number(),
     variation: z.number(),

--- a/jobs/dtd-metrics/src/models/metrics.model.ts
+++ b/jobs/dtd-metrics/src/models/metrics.model.ts
@@ -92,6 +92,18 @@ export const OnboardedTenantsCountMetric = z.tuple([
     variation: z.number(),
   }),
   z.object({
+    name: z.literal('Pubblici'),
+    totalCount: z.number(),
+    lastMonthCount: z.number(),
+    variation: z.number(),
+  }),
+  z.object({
+    name: z.literal('Privati'),
+    totalCount: z.number(),
+    lastMonthCount: z.number(),
+    variation: z.number(),
+  }),
+  z.object({
     name: z.literal(MACRO_CATEGORIES[2].name),
     totalCount: z.number(),
     lastMonthCount: z.number(),

--- a/jobs/dtd-metrics/src/utils/__tests__/helpers.utils.test.ts
+++ b/jobs/dtd-metrics/src/utils/__tests__/helpers.utils.test.ts
@@ -1,23 +1,4 @@
-import { getOnboardedTenants, json2csv, toSnakeCase } from '../helpers.utils.js'
-
-describe('getOnboardedTenants', () => {
-  it('should return the correct onboarded tenants', () => {
-    const todayDate = new Date()
-    const tenants = [
-      { onboardedAt: todayDate },
-      { onboardedAt: todayDate },
-      { onboardedAt: todayDate },
-      { onboardedAt: undefined },
-      { onboardedAt: todayDate },
-    ]
-    expect(getOnboardedTenants(tenants)).toEqual([
-      { onboardedAt: todayDate },
-      { onboardedAt: todayDate },
-      { onboardedAt: todayDate },
-      { onboardedAt: todayDate },
-    ])
-  })
-})
+import { json2csv, toSnakeCase } from '../helpers.utils.js'
 
 describe('toSnakeCase', () => {
   it('should return the correct snake case string', () => {

--- a/jobs/dtd-metrics/src/utils/helpers.utils.ts
+++ b/jobs/dtd-metrics/src/utils/helpers.utils.ts
@@ -11,16 +11,6 @@ export function getVariationPercentage(current: number, total: number): number {
   return total === 0 ? 0 : Number(((current / total) * 100).toFixed(1))
 }
 
-/**
- * Returns the tenants considered onboarded, i.e. the tenants that have an onboardedAt date
- */
-export function getOnboardedTenants<TTenants extends { onboardedAt?: Date | undefined }>(
-  tenants: Array<TTenants>
-): Array<TTenants & { onboardedAt: Date }> {
-  const isOnboarded = (tenant: TTenants): tenant is TTenants & { onboardedAt: Date } => !!tenant.onboardedAt
-  return tenants.filter(isOnboarded)
-}
-
 const cidJob = randomUUID()
 
 export const log = {


### PR DESCRIPTION
In this PR:

- Removed `onboardedTenants` property in `GlobalStore`. This was a leftover of when all the tenants, even the not-onboarded ones, were fetched from the read-model.
- Added `notIPATenants` property in the `GlobalStore`.
- Updated `onboarded-tenants-count` metric to include Pubblici and Privati counts.