### PR TITLE
PIN-4509: ANAC agreements archiviation for tenants not in file

### DIFF
--- a/jobs/anac-certified-attributes-importer/src/config/env.ts
+++ b/jobs/anac-certified-attributes-importer/src/config/env.ts
@@ -26,6 +26,7 @@ const Env = z.object({
   READ_MODEL_DB_NAME: z.string(),
 
   TENANT_PROCESS_URL: z.string(),
+  AGREEMENT_PROCESS_URL: z.string(),
 
   INTERNAL_JWT_KID: z.string(),
   INTERNAL_JWT_SUBJECT: z.string(),

--- a/jobs/anac-certified-attributes-importer/src/index.ts
+++ b/jobs/anac-certified-attributes-importer/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@interop-be-reports/commons'
 import { ReadModelQueries, SftpClient, TenantProcessService, importAttributes } from './service/index.js'
 import { SftpConfig, env } from './config/index.js'
+import { AgreementProcessService } from './service/agreement-process.service.js'
 
 const readModelConfig: ReadModelConfig = {
   mongodbReplicaSet: env.MONGODB_REPLICA_SET,
@@ -44,11 +45,13 @@ const readModelQueries: ReadModelQueries = new ReadModelQueries(readModelClient)
 
 const tokenGenerator = new InteropTokenGenerator(tokenGeneratorConfig)
 const refreshableToken = new RefreshableInteropToken(tokenGenerator)
+const agreementProcess = new AgreementProcessService(env.AGREEMENT_PROCESS_URL)
 const tenantProcess = new TenantProcessService(env.TENANT_PROCESS_URL)
 
 await importAttributes(
   sftpClient,
   readModelQueries,
+  agreementProcess,
   tenantProcess,
   refreshableToken,
   env.RECORDS_PROCESS_BATCH_SIZE,

--- a/jobs/anac-certified-attributes-importer/src/model/agreement.model.ts
+++ b/jobs/anac-certified-attributes-importer/src/model/agreement.model.ts
@@ -1,0 +1,5 @@
+import { Agreement } from '@interop-be-reports/commons'
+import { z } from 'zod'
+
+export const PersistentAgreement = Agreement.pick({ id: true })
+export type PersistentAgreement = z.infer<typeof PersistentAgreement>

--- a/jobs/anac-certified-attributes-importer/src/model/index.ts
+++ b/jobs/anac-certified-attributes-importer/src/model/index.ts
@@ -1,3 +1,4 @@
+export * from './agreement.model.js'
 export * from './attribute.model.js'
 export * from './csv-row.model.js'
 export * from './interop-context.model.js'

--- a/jobs/anac-certified-attributes-importer/src/service/__tests__/helpers.ts
+++ b/jobs/anac-certified-attributes-importer/src/service/__tests__/helpers.ts
@@ -1,5 +1,5 @@
 import { ANAC_ABILITATO_CODE, ANAC_INCARICATO_CODE, ANAC_IN_CONVALIDA_CODE, SftpConfig } from '../../config/index.js'
-import { InteropContext, PersistentAttribute, PersistentTenant, PersistentTenantAttribute } from '../../model/index.js'
+import { InteropContext, PersistentAgreement, PersistentAttribute, PersistentTenant, PersistentTenantAttribute } from '../../model/index.js'
 
 export const sftpConfigTest: SftpConfig = {
   host: 'host',
@@ -20,15 +20,17 @@ export const ATTRIBUTE_ANAC_INCARICATO_ID = 'b1d64ee0-fda9-48e2-84f8-1b62f1292b4
 export const ATTRIBUTE_ANAC_ABILITATO_ID = 'dc77c852-7635-4522-bc1c-e431c5d68b55'
 export const ATTRIBUTE_ANAC_IN_CONVALIDA_ID = '97dec753-8a6e-4a25-aa02-95ac8602b364'
 
+export const archivableAgreements: PersistentAgreement[] = [{ id: 'd250a831-d89f-4eed-b516-33bc36c0ce87' }, { id: 'e999635d-d2f0-4c8e-bf7e-c0db789102a7' }]
+
 export const downloadCSVMockGenerator = (csvContent: string) => (): Promise<string> => Promise.resolve(csvContent)
 export const getTenantsMockGenerator =
   (f: (codes: string[]) => PersistentTenant[]) =>
-  (codes: string[]): Promise<PersistentTenant[]> =>
-    Promise.resolve(f(codes))
+    (codes: string[]): Promise<PersistentTenant[]> =>
+      Promise.resolve(f(codes))
 export const getTenantByIdMockGenerator =
   (f: (tenantId: string) => PersistentTenant) =>
-  (tenantId: string): Promise<PersistentTenant> =>
-    Promise.resolve(f(tenantId))
+    (tenantId: string): Promise<PersistentTenant> =>
+      Promise.resolve(f(tenantId))
 
 export const downloadCSVMock = downloadCSVMockGenerator(csvFileContent)
 
@@ -44,6 +46,10 @@ export const internalRevokeCertifiedAttributeMock = (
   _tenantExternalId: string,
   _attributeOrigin: string,
   _attributeExternalId: string,
+  _context: InteropContext
+): Promise<void> => Promise.resolve()
+export const archiveAgreementMock = (
+  _agreementId: string,
   _context: InteropContext
 ): Promise<void> => Promise.resolve()
 
@@ -71,6 +77,8 @@ export const getAttributeByExternalIdMock = (origin: string, code: string): Prom
   }
 }
 export const getTenantsWithAttributesMock = (_: string[]) => Promise.resolve([])
+
+export const getArchivableAgreementsMock = (_t: string, _a: string[]) => Promise.resolve(archivableAgreements)
 
 export const persistentTenant: PersistentTenant = {
   id: '091fbea1-0c8e-411b-988f-5098b6a33ba7',

--- a/jobs/anac-certified-attributes-importer/src/service/__tests__/processor.test.ts
+++ b/jobs/anac-certified-attributes-importer/src/service/__tests__/processor.test.ts
@@ -28,7 +28,6 @@ import {
 } from './helpers.js'
 import { PersistentTenant } from '../../model/tenant.model.js'
 import { AgreementProcessService } from '../agreement-process.service.js'
-import { PersistentAgreement } from '../../model/agreement.model.js'
 
 describe('ANAC Certified Attributes Importer', () => {
   const tokenGeneratorMock = {} as InteropTokenGenerator

--- a/jobs/anac-certified-attributes-importer/src/service/agreement-process.service.ts
+++ b/jobs/anac-certified-attributes-importer/src/service/agreement-process.service.ts
@@ -1,0 +1,31 @@
+import axios from 'axios'
+import { InteropContext } from '../model/index.js'
+import { logError } from '@interop-be-reports/commons'
+
+export class AgreementProcessService {
+  constructor(private agreementProcessUrl: string) { }
+
+  public async archiveAgreement(
+    agreementId: string,
+    context: InteropContext
+  ): Promise<void> {
+    const { data } = await axios
+      .post<void>(
+        `${this.agreementProcessUrl}/agreements/${agreementId}/archive`,
+        undefined,
+        {
+          headers: {
+            'X-Correlation-Id': context.correlationId,
+            'Authorization': `Bearer ${context.bearerToken}`,
+            'Content-Type': false,
+          },
+        }
+      )
+      .catch((err) => {
+        logError(context.correlationId, `Error on archiveAgreement. Reason: ${err.message}`)
+        throw Error(`Unexpected response from archiveAgreement. Reason: ${err.message}`)
+      })
+    return data
+  }
+
+}

--- a/jobs/anac-certified-attributes-importer/src/service/processor.ts
+++ b/jobs/anac-certified-attributes-importer/src/service/processor.ts
@@ -18,8 +18,8 @@ import { AgreementProcessService } from './agreement-process.service.js'
 export async function importAttributes(
   sftpClient: SftpClient,
   readModel: ReadModelQueries,
-  tenantProcess: TenantProcessService,
   agreementProcess: AgreementProcessService,
+  tenantProcess: TenantProcessService,
   refreshableToken: RefreshableInteropToken,
   recordsBatchSize: number,
   anacTenantId: string

--- a/jobs/anac-certified-attributes-importer/src/service/read-model-queries.service.ts
+++ b/jobs/anac-certified-attributes-importer/src/service/read-model-queries.service.ts
@@ -1,6 +1,7 @@
 import { ReadModelClient } from '@interop-be-reports/commons'
 import { PersistentTenant } from '../model/tenant.model.js'
 import { PersistentAttribute } from '../model/attribute.model.js'
+import { PersistentAgreement } from '../model/index.js'
 
 const projectUnrevokedCertifiedAttributes = {
   _id: 0,
@@ -119,6 +120,28 @@ export class ReadModelQueries {
         },
       ])
       .map(({ data }) => PersistentTenant.parse(data))
+      .toArray()
+  }
+
+  async getArchivableAgreements(tenantId: string, attributeIds: string[]): Promise<PersistentAgreement[]> {
+    return await this.readModelClient.agreements
+      .aggregate([
+        {
+          // TODO Query to be defined
+          $match: {
+            'data.consumerId': tenantId,
+            'data.state': { $in: ['Active', 'Suspended'] },
+            'data.certifiedAttributes.id': { $in: attributeIds },
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            'data.id': 1
+          },
+        },
+      ])
+      .map(({ data }) => PersistentAgreement.parse(data))
       .toArray()
   }
 


### PR DESCRIPTION
TODO: we still need to define the condition to retrieve agreements to be archived.
E.g. if the descriptor defines attributes as `ANAC_incaricato OR Comuni`, should be archive the agreements?