### PR TITLE
Fix tokens trend metric data

### DIFF
--- a/jobs/dtd-metrics/src/metrics/__tests__/tokens-trend.metric.test.ts
+++ b/jobs/dtd-metrics/src/metrics/__tests__/tokens-trend.metric.test.ts
@@ -7,9 +7,8 @@ import { getTokensTrendMetric } from '../tokens-trend.metric.js'
 
 function getTokensByDayMock(): { totalTokens: number; tokensByDay: TokensByDay } {
   const tokensByDayMock = [
-    { day: sub(new Date(), { months: 4 }), tokens: 1 },
-    { day: sub(new Date(), { months: 3 }), tokens: 2 },
-    { day: new Date(), tokens: 3 },
+    { day: sub(new Date(), { months: 10 }), tokens: 1 },
+    { day: sub(new Date(), { days: 1 }), tokens: 10 },
   ]
   return {
     totalTokens: aggregateTokensCount(tokensByDayMock),
@@ -27,14 +26,8 @@ describe('getTokensTrendMetric', () => {
   it('should return the correct metrics', async () => {
     const result = await getTokensTrendMetric({} as ReadModelClient, {} as GlobalStoreService)
 
-    expect(result.fromTheBeginning[result.fromTheBeginning.length - 1].count).toStrictEqual(
-      getTokensByDayMock().totalTokens
-    )
-
-    expect(result.lastSixMonths[result.lastSixMonths.length - 1].count).toStrictEqual(getTokensByDayMock().totalTokens)
-
-    expect(result.lastTwelveMonths[result.lastTwelveMonths.length - 1].count).toStrictEqual(
-      getTokensByDayMock().totalTokens
-    )
+    expect(result.fromTheBeginning[result.fromTheBeginning.length - 1].count).toStrictEqual(10)
+    expect(result.lastSixMonths[result.lastSixMonths.length - 1].count).toStrictEqual(10)
+    expect(result.lastTwelveMonths[result.lastTwelveMonths.length - 1].count).toStrictEqual(10)
   })
 })


### PR DESCRIPTION
This PR fixes the way the tokens trend metric data are being generated.
Before every data point was the cumulative of the total tokens up to that date. 
This has been changed, now every data point contains only the count of the tokens for that specific period of time.