### PR TITLE
PIN-4625 - Add data for macrocategory producer filters

### DIFF
--- a/jobs/dtd-metrics/src/metrics/__tests__/most-subscribed-e-services.metric.test.ts
+++ b/jobs/dtd-metrics/src/metrics/__tests__/most-subscribed-e-services.metric.test.ts
@@ -193,7 +193,7 @@ describe('getMostSubscribedEServicesMetric', () => {
     const globalStore = await GlobalStoreService.init(readModelMock)
     const result = await getMostSubscribedEServicesMetric(readModelMock, globalStore)
 
-    const comuniTop10 = result.fromTheBeginning.find(
+    const comuniTop10 = result.fromTheBeginning[0].data.find(
       (a) => (a.name as MacroCategoryName) === 'Aziende Ospedaliere e ASL'
     )?.mostSubscribedEServices
 
@@ -205,7 +205,7 @@ describe('getMostSubscribedEServicesMetric', () => {
     expect(comuniTop10?.[1].producerName).toStrictEqual('Producer')
     expect(comuniTop10?.[1].subscribersCount).toStrictEqual(1)
 
-    const aziendeOspedaliereTop10 = result.fromTheBeginning.find(
+    const aziendeOspedaliereTop10 = result.fromTheBeginning[0].data.find(
       (a) => (a.name as MacroCategoryName) === 'Aziende Ospedaliere e ASL'
     )?.mostSubscribedEServices
 

--- a/jobs/dtd-metrics/src/metrics/__tests__/top-producers-by-subscribers.metric.test.ts
+++ b/jobs/dtd-metrics/src/metrics/__tests__/top-producers-by-subscribers.metric.test.ts
@@ -58,12 +58,14 @@ describe('getTopProducersBySubscribersMetric', () => {
         data: getTenantMock({
           id: producer1Uuid,
           name: 'Producer 1',
+          attributes: [{ id: comuneAttributeUuid, type: 'PersistentCertifiedAttribute' }],
         }),
       },
       {
         data: getTenantMock({
           id: producer2Uuid,
           name: 'Producer 2',
+          attributes: [{ id: comuneAttributeUuid, type: 'PersistentCertifiedAttribute' }],
         }),
       },
       {
@@ -100,7 +102,7 @@ describe('getTopProducersBySubscribersMetric', () => {
     const globalStore = await GlobalStoreService.init(readModelMock)
     const result = await getTopProducersBySubscribersMetric(readModelMock, globalStore)
 
-    const producer1 = result.fromTheBeginning[0]
+    const producer1 = result.fromTheBeginning[0].data[0]
     expect(producer1.producerName).toStrictEqual('Producer 1')
 
     const producer1Comuni = producer1.macroCategories.find((a) => (a.name as MacroCategoryName) === 'Comuni')
@@ -112,7 +114,7 @@ describe('getTopProducersBySubscribersMetric', () => {
     expect(producer1Comuni?.subscribersCount).toStrictEqual(1)
     expect(producer1AziendeOspedaliere?.subscribersCount).toStrictEqual(1)
 
-    const producer2 = result.fromTheBeginning[1]
+    const producer2 = result.fromTheBeginning[0].data[1]
     expect(producer2.producerName).toStrictEqual('Producer 2')
     const producer2Comuni = producer2.macroCategories.find((a) => (a.name as MacroCategoryName) === 'Comuni')
     const producer2AziendeOspedaliere = producer2.macroCategories.find(

--- a/jobs/dtd-metrics/src/metrics/top-producers.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/top-producers.metric.ts
@@ -1,30 +1,56 @@
 import { EServiceDescriptor, ReadModelClient, TENANTS_COLLECTION_NAME } from '@interop-be-reports/commons'
-import { TopProducersMetricItem, TopProducersMetric } from '../models/metrics.model.js'
+import { TopProducersMetric, TopProducersMetricItem } from '../models/metrics.model.js'
 import { getMonthsAgoDate } from '../utils/helpers.utils.js'
 import { MetricFactoryFn } from '../services/metrics-producer.service.js'
+import { Document } from 'mongodb'
 
 /**
  * @see https://pagopa.atlassian.net/browse/PIN-4215
  */
-export const getTopProducersMetric: MetricFactoryFn<'entiChePubblicanoPiuEService'> = async (readModel) => {
+export const getTopProducersMetric: MetricFactoryFn<'entiChePubblicanoPiuEService'> = async (
+  readModel,
+  globalStore
+) => {
   const sixMonthsAgoDate = getMonthsAgoDate(6)
   const twelveMonthsAgoDate = getMonthsAgoDate(12)
   const fromTheBeginningDate = undefined
 
-  const [lastSixMonths, lastTwelveMonths, fromTheBeginning] = await Promise.all(
-    [sixMonthsAgoDate, twelveMonthsAgoDate, fromTheBeginningDate].map((date) =>
-      getTopProducersMetricFromDate(readModel, date)
-    )
-  )
+  const allTenantsIds = globalStore.tenants.map((tenant) => tenant.id)
+  const macroCategoriesData = [
+    { id: '0', name: 'Totale', tenantsIds: allTenantsIds },
+    ...globalStore.macroCategories.map((category) => ({
+      id: category.id,
+      name: category.name,
+      tenantsIds: category.tenantsIds,
+    })),
+  ]
 
-  return TopProducersMetric.parse({ lastSixMonths, lastTwelveMonths, fromTheBeginning })
+  const getTimedMetricData = async (date?: Date): Promise<TopProducersMetric[keyof TopProducersMetric]> => {
+    return await Promise.all(
+      // For each macro category, get the top producers
+      macroCategoriesData.map(async ({ id, name, tenantsIds }) => ({
+        id,
+        name,
+        data: await getTopProducersMetricItems(readModel, tenantsIds, date),
+      }))
+    )
+  }
+
+  return {
+    lastSixMonths: await getTimedMetricData(sixMonthsAgoDate),
+    lastTwelveMonths: await getTimedMetricData(twelveMonthsAgoDate),
+    fromTheBeginning: await getTimedMetricData(fromTheBeginningDate),
+  }
 }
 
-export async function getTopProducersMetricFromDate(
+export async function getTopProducersMetricItems(
   readModel: ReadModelClient,
-  date: Date | undefined
+  tenantsIds: Array<string>,
+  date?: Date
 ): Promise<Array<TopProducersMetricItem>> {
-  const publishedDateFilter = date
+  // If date is not provided, the filter will be ignored
+  // If date is provided, the filter will return only the e-services published after that date
+  const publishedDateFilter: Document = date
     ? {
         'data.descriptors': {
           $elemMatch: {
@@ -41,20 +67,25 @@ export async function getTopProducersMetricFromDate(
     .aggregate([
       {
         $match: {
+          // Takes into account only the e-services with at least one published or suspended descriptor
           'data.descriptors.state': {
             $in: ['Published', 'Suspended'] satisfies Array<EServiceDescriptor['state']>,
           },
+          'data.producerId': { $in: tenantsIds },
           ...publishedDateFilter,
         },
       },
+      // Group by producerId and count the e-services
       {
         $group: {
           _id: '$data.producerId',
           count: { $sum: 1 },
         },
       },
+      // Sort by the e-service count and take the top 10
       { $sort: { count: -1 } },
       { $limit: 10 },
+      // Join with the tenants collection to get the producer name
       {
         $lookup: {
           from: TENANTS_COLLECTION_NAME,

--- a/jobs/dtd-metrics/src/models/metrics.model.ts
+++ b/jobs/dtd-metrics/src/models/metrics.model.ts
@@ -134,7 +134,15 @@ export const TopProducersMetricItem = z.object({
 
 export type TopProducersMetricItem = z.infer<typeof TopProducersMetricItem>
 
-export const TopProducersMetric = TimedMetric(z.array(TopProducersMetricItem))
+export const TopProducersMetric = TimedMetric(
+  z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      data: z.array(TopProducersMetricItem),
+    })
+  )
+)
 export type TopProducersMetric = z.infer<typeof TopProducersMetric>
 
 export const TotalTokensMetric = z.object({

--- a/jobs/dtd-metrics/src/models/metrics.model.ts
+++ b/jobs/dtd-metrics/src/models/metrics.model.ts
@@ -49,12 +49,18 @@ export type MostSubscribedEServicesMetric = z.infer<typeof MostSubscribedEServic
 export const TopProducersBySubscribersMetric = TimedMetric(
   z.array(
     z.object({
-      producerName: z.string(),
-      macroCategories: z.array(
+      id: z.string(),
+      name: z.string(),
+      data: z.array(
         z.object({
-          id: z.string(),
-          name: z.string(),
-          subscribersCount: z.number(),
+          producerName: z.string(),
+          macroCategories: z.array(
+            z.object({
+              id: z.string(),
+              name: z.string(),
+              subscribersCount: z.number(),
+            })
+          ),
         })
       ),
     })

--- a/jobs/dtd-metrics/src/models/metrics.model.ts
+++ b/jobs/dtd-metrics/src/models/metrics.model.ts
@@ -34,11 +34,17 @@ export const MostSubscribedEServicesMetric = TimedMetric(
     z.object({
       id: z.string(),
       name: z.string(),
-      mostSubscribedEServices: z.array(
+      data: z.array(
         z.object({
-          eserviceName: z.string(),
-          producerName: z.string(),
-          subscribersCount: z.number(),
+          id: z.string(),
+          name: z.string(),
+          mostSubscribedEServices: z.array(
+            z.object({
+              eserviceName: z.string(),
+              producerName: z.string(),
+              subscribersCount: z.number(),
+            })
+          ),
         })
       ),
     })


### PR DESCRIPTION
This PR enriches the data of three metrics, allowing the frontend to easily filter it by the producer's macrocategory.

The changes on each metric have their own commit, so I suggest to look at this PR commit by commit.