### PR TITLE
Metrics report generator fixes

### DIFF
--- a/jobs/commons/src/services/athena-client.service.ts
+++ b/jobs/commons/src/services/athena-client.service.ts
@@ -43,11 +43,11 @@ export class AthenaClientService {
     let result: GetQueryResultsCommandOutput | undefined
 
     do {
-      const queryResult = await this.athena.send(new GetQueryResultsCommand({ QueryExecutionId, NextToken }))
-      NextToken = queryResult.NextToken
+      const queryResult = await this.athena.send(new GetQueryResultsCommand({ QueryExecutionId, NextToken: nextToken }))
+      nextToken = queryResult.NextToken
       if (!result) result = queryResult
       else if (queryResult.ResultSet?.Rows) result.ResultSet?.Rows?.push(...queryResult.ResultSet.Rows)
-    } while (NextToken)
+    } while (nextToken)
 
     if (!result) throw new Error('No result was returned from Athena')
 

--- a/jobs/commons/src/services/athena-client.service.ts
+++ b/jobs/commons/src/services/athena-client.service.ts
@@ -39,7 +39,7 @@ export class AthenaClientService {
     // Polls until the query execution is complete
     await this.pollUntilComplete(QueryExecutionId)
 
-    let NextToken: string | undefined
+    let nextToken: string | undefined
     let result: GetQueryResultsCommandOutput | undefined
 
     do {

--- a/jobs/metrics-report-generator/src/models/excel.model.ts
+++ b/jobs/metrics-report-generator/src/models/excel.model.ts
@@ -8,7 +8,7 @@ export const AgreementsWorksheetTableData = z.object({
   ProducerId: z.string(),
   Consumer: z.string(),
   ConsumerId: z.string(),
-  Agreement: z.string(),
+  AgreementId: z.string(),
   Purposes: z.string(),
   PurposeIds: z.string(),
 })
@@ -22,6 +22,7 @@ export const DescriptorsWorksheetTableData = z.object({
   DescriptorId: z.string(),
   State: DescriptorState,
   Fingerprint: z.string(),
+  TokenDuration: z.string(),
 })
 export type DescriptorsWorksheetTableData = z.infer<typeof DescriptorsWorksheetTableData>
 

--- a/jobs/metrics-report-generator/src/models/query-data.model.ts
+++ b/jobs/metrics-report-generator/src/models/query-data.model.ts
@@ -11,7 +11,7 @@ import { z } from 'zod'
 export const EServiceQueryData = EService.pick({ id: true, name: true, producerId: true }).and(
   z.object({
     descriptors: z.array(
-      EServiceDescriptor.pick({ id: true, createdAt: true, state: true }).and(
+      EServiceDescriptor.pick({ id: true, createdAt: true, state: true, voucherLifespan: true }).and(
         z.object({ interface: CatalogDocument.pick({ checksum: true }).optional() })
       )
     ),

--- a/jobs/metrics-report-generator/src/services/read-model-queries.service.ts
+++ b/jobs/metrics-report-generator/src/services/read-model-queries.service.ts
@@ -38,6 +38,7 @@ export class ReadModelQueriesService {
         'data.descriptors.createdAt': 1,
         'data.descriptors.state': 1,
         'data.descriptors.interface.checksum': 1,
+        'data.descriptors.voucherLifespan': 1,
       },
     })
   }

--- a/jobs/metrics-report-generator/src/utils/helpers.util.ts
+++ b/jobs/metrics-report-generator/src/utils/helpers.util.ts
@@ -23,7 +23,9 @@ export function generateAgreementsWorksheetTableData(
   tenantsMap: Map<string, TenantQueryData>
 ): AgreementsWorksheetTableData[] {
   return agreements.map<AgreementsWorksheetTableData>((agreement) => {
-    const agreementPurposes = purposes.filter((purpose) => purpose.eserviceId === agreement.eserviceId && purpose.consumerId === agreement.consumerId)
+    const agreementPurposes = purposes.filter(
+      (purpose) => purpose.eserviceId === agreement.eserviceId && purpose.consumerId === agreement.consumerId
+    )
     const consumer = tenantsMap.get(agreement.consumerId)
     const producer = tenantsMap.get(agreement.producerId)
     const eservice = eservicesMap.get(agreement.eserviceId)
@@ -35,11 +37,12 @@ export function generateAgreementsWorksheetTableData(
     return {
       EserviceId: agreement.eserviceId,
       Eservice: eservice?.name ?? '',
-      Producer: producer?.externalId.value ?? '',
       ProducerId: agreement.producerId,
-      Consumer: consumer?.externalId.value ?? '',
+      Producer: producer?.externalId.value ?? '',
       ConsumerId: agreement.consumerId,
-      Agreement: agreement.id,
+      Consumer: consumer?.externalId.value ?? '',
+      AgreementId: agreement.id,
+      State: agreement.state,
       Purposes: agreementPurposes.map((purpose) => purpose.title).join(','),
       PurposeIds: agreementPurposes.map((purpose) => purpose.id).join(','),
     }
@@ -63,7 +66,7 @@ export function generateDescriptorsWorksheetTableData(
 
       if (!tenant) log.warn(`[Descriptors Worksheet] Tenant producer ${eservice.producerId} not found in readmodel`)
 
-      const data = {
+      const data: DescriptorsWorksheetTableData = {
         Name: eservice.name,
         CreatedAt: descriptor.createdAt.toISOString(),
         ProducerId: eservice.producerId,
@@ -71,6 +74,7 @@ export function generateDescriptorsWorksheetTableData(
         DescriptorId: descriptor.id,
         State: descriptor.state,
         Fingerprint: interfaceChecksum,
+        TokenDuration: descriptor.voucherLifespan.toString(),
       }
       return [...acc, data]
     }, [])


### PR DESCRIPTION
This PR fixes some issues with the metrics report generator job.

- Added handling athena result pagination;
- In `agreements` sheet, updated column name from `Agreement` to `AgreementId`;
- Updated order columns in `agreements` sheet;
- Added `TokenDuration` column in `descriptors` sheet; 

Output example:
[report-uat.xlsx](https://github.com/pagopa/interop-be-reports/files/14694098/report-uat.xlsx)
