### PR TITLE
PIN-4885 -  Fix e-services num count discrepancy

### DIFF
--- a/jobs/dtd-metrics/src/metrics/__tests__/published-e-services.metric.test.ts
+++ b/jobs/dtd-metrics/src/metrics/__tests__/published-e-services.metric.test.ts
@@ -1,23 +1,43 @@
-import { getEServiceMock } from '@interop-be-reports/commons'
-import { readModelMock, seedCollection } from '../../utils/tests.utils.js'
+import { getEServiceMock, getTenantMock } from '@interop-be-reports/commons'
+import { MacroCategoryCodeFor, readModelMock, seedCollection } from '../../utils/tests.utils.js'
 import { GlobalStoreService } from '../../services/global-store.service.js'
 import { getPublishedEServicesMetric } from '../published-e-services.metric.js'
+import { randomUUID } from 'crypto'
+
+const producerUUID = randomUUID()
+const comuniAttributeUUID = randomUUID()
 
 describe('getPublishedEServicesMetric', () => {
   it('should return the correct metrics', async () => {
     const today = new Date()
     const moreThanOneMonthAgo = new Date(today)
 
+    await seedCollection('tenants', [
+      {
+        data: getTenantMock({
+          id: producerUUID,
+          attributes: [{ id: comuniAttributeUUID }],
+          onboardedAt: new Date().toISOString(),
+        }),
+      },
+    ])
+
+    await seedCollection('attributes', [
+      { data: { id: comuniAttributeUUID, code: 'L18' satisfies MacroCategoryCodeFor<'Comuni'> } },
+    ])
+
     moreThanOneMonthAgo.setDate(moreThanOneMonthAgo.getDate() - 40)
 
     await seedCollection('eservices', [
       {
         data: getEServiceMock({
+          producerId: producerUUID,
           descriptors: [{ version: '1', state: 'Published', publishedAt: today.toISOString() }],
         }),
       },
       {
         data: getEServiceMock({
+          producerId: producerUUID,
           descriptors: [
             { version: '1', state: 'Suspended', publishedAt: today.toISOString() },
             { version: '2', state: 'Draft' },
@@ -26,13 +46,14 @@ describe('getPublishedEServicesMetric', () => {
       },
       {
         data: getEServiceMock({
+          producerId: producerUUID,
           descriptors: [
             { version: '1', state: 'Suspended', publishedAt: moreThanOneMonthAgo.toISOString() },
             { version: '2', state: 'Deprecated' },
           ],
         }),
       },
-      { data: getEServiceMock({ descriptors: [{ state: 'Draft' }] }) },
+      { data: getEServiceMock({ producerId: producerUUID, descriptors: [{ state: 'Draft' }] }) },
     ])
 
     const globalStore = await GlobalStoreService.init(readModelMock)

--- a/jobs/dtd-metrics/src/metrics/published-e-services.metric.ts
+++ b/jobs/dtd-metrics/src/metrics/published-e-services.metric.ts
@@ -7,10 +7,15 @@ import { MetricFactoryFn } from '../services/metrics-producer.service.js'
 /**
  * @see https://pagopa.atlassian.net/browse/PIN-3744
  **/
-export const getPublishedEServicesMetric: MetricFactoryFn<'eservicePubblicati'> = async (readModel) => {
+export const getPublishedEServicesMetric: MetricFactoryFn<'eservicePubblicati'> = async (readModel, globalStore) => {
   const oneMonthAgoDate = getMonthsAgoDate(1)
 
   const publishedEServiceFilter: Document = {
+    // Only count e-services that belong to tenants that are in the global store,
+    // The global store filters out AOO/UO tenants
+    'data.producerId': {
+      $in: Array.from(globalStore.tenantsMap.keys()),
+    },
     'data.descriptors.state': {
       $in: ['Published', 'Suspended'] satisfies Array<EServiceDescriptor['state']>,
     },


### PR DESCRIPTION
Fix a discrepancy on the value of the total number of e-service between two metrics.
The difference was about that the `eservicePubblicati` metric counted all the e-services, even the one producer by the AOO/UO, while the `distribuzioneEServicePerEntiErogatori` no.