### PR TITLE
PIN-5018 - Added compression to excel generation

### DIFF
--- a/jobs/metrics-report-generator/src/services/excel-generator.service.ts
+++ b/jobs/metrics-report-generator/src/services/excel-generator.service.ts
@@ -25,7 +25,9 @@ export class ExcelGenerator {
   }
 
   public async generateExcelFile(): Promise<Buffer> {
-    return (await this.workbook.xlsx.writeBuffer()) as Buffer
+    return (await this.workbook.xlsx.writeBuffer({
+      zip: { compression: 'DEFLATE', compressionOptions: { level: 9 } },
+    })) as Buffer
   }
 
   private adjustColumnWidths(worksheet: ExcelJs.Worksheet): void {


### PR DESCRIPTION
This change took the output excel file size, from an UAT run, from 2.464.392 byte to 2.376.235 byte