### PR TITLE
Fix publish CI: updated turbo and Dockerfiles

### DIFF
--- a/jobs/anac-certified-attributes-importer/Dockerfile
+++ b/jobs/anac-certified-attributes-importer/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN corepack enable
 COPY . .
 RUN pnpm install --frozen-lockfile
-RUN pnpm turbo prune --scope=ivass-certified-attributes-importer --docker
+RUN pnpm turbo prune --scope=anac-certified-attributes-importer --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules

--- a/jobs/anac-certified-attributes-importer/Dockerfile
+++ b/jobs/anac-certified-attributes-importer/Dockerfile
@@ -8,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=anac-certified-attributes-importer --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=ivass-certified-attributes-importer --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -24,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=anac-certified-attributes-importer
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=anac-certified-attributes-importer
 
 CMD node ./jobs/anac-certified-attributes-importer/dist

--- a/jobs/datalake-data-export/Dockerfile
+++ b/jobs/datalake-data-export/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:18-alpine AS base
 
 FROM base AS builder
@@ -9,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=datalake-data-export --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=datalake-data-export --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -25,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=datalake-data-export
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=datalake-data-export
 
 CMD node ./jobs/datalake-data-export/dist

--- a/jobs/dtd-catalog-exporter/Dockerfile
+++ b/jobs/dtd-catalog-exporter/Dockerfile
@@ -8,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=dtd-catalog-exporter --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=dtd-catalog-exporter --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -24,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=dtd-catalog-exporter
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=dtd-catalog-exporter
 
 CMD node ./jobs/dtd-catalog-exporter/dist

--- a/jobs/dtd-catalog-total-load-exporter/Dockerfile
+++ b/jobs/dtd-catalog-total-load-exporter/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:18-alpine AS base
 
 FROM base AS builder
@@ -9,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=dtd-catalog-total-load-exporter --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=dtd-catalog-total-load-exporter --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -25,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=dtd-catalog-total-load-exporter
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=dtd-catalog-total-load-exporter
 
 CMD node ./jobs/dtd-catalog-total-load-exporter/dist

--- a/jobs/dtd-metrics/Dockerfile
+++ b/jobs/dtd-metrics/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:18-alpine AS base
 
 FROM base AS builder
@@ -9,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=dtd-metrics --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=dtd-metrics --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -25,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=dtd-metrics
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=dtd-metrics
 
 CMD node ./jobs/dtd-metrics/dist

--- a/jobs/ivass-certified-attributes-importer/Dockerfile
+++ b/jobs/ivass-certified-attributes-importer/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:18-alpine AS base
 
 FROM base AS builder
@@ -9,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=ivass-certified-attributes-importer --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=ivass-certified-attributes-importer --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -25,30 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
-
-# Install dependencies for Puppeteer
-RUN apk add --no-cache \
-      chromium \
-      nss \
-      freetype \
-      harfbuzz \
-      ca-certificates \
-      ttf-freefont
-
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-
-# Add user so we don't need --no-sandbox.
-RUN addgroup -S pptruser && adduser -S -G pptruser pptruser
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-
-RUN chown -R pptruser:pptruser /app
- 
-# Run everything after as non-privileged user.
-USER pptruser
-
-RUN pnpm dlx turbo run build --filter=ivass-certified-attributes-importer
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=ivass-certified-attributes-importer
 
 CMD node ./jobs/ivass-certified-attributes-importer/dist

--- a/jobs/metrics-report-generator/Dockerfile
+++ b/jobs/metrics-report-generator/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM node:18-alpine AS base
 
 FROM base AS builder
@@ -9,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=metrics-report-generator --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=metrics-report-generator --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -25,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=metrics-report-generator
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=metrics-report-generator
 
 CMD node ./jobs/metrics-report-generator/dist

--- a/jobs/one-trust-notices/Dockerfile
+++ b/jobs/one-trust-notices/Dockerfile
@@ -8,7 +8,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=one-trust-notices --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=one-trust-notices --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -24,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=one-trust-notices
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=one-trust-notices
 
 CMD node ./jobs/one-trust-notices/dist

--- a/jobs/pn-consumers/Dockerfile
+++ b/jobs/pn-consumers/Dockerfile
@@ -8,7 +8,11 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=pn-consumers --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=pn-consumers --docker
+
+# remove all empty node_modules folder structure
+RUN rm -rf /app/out/full/*/*/node_modules
 
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer
@@ -21,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=pn-consumers
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=pn-consumers
 
 CMD node ./jobs/pn-consumers/dist

--- a/jobs/selfcare-onboarding-consumer/Dockerfile
+++ b/jobs/selfcare-onboarding-consumer/Dockerfile
@@ -8,7 +8,11 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=selfcare-onboarding-consumer --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=selfcare-onboarding-consumer --docker
+
+# remove all empty node_modules folder structure
+RUN rm -rf /app/out/full/*/*/node_modules
 
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer
@@ -21,10 +25,10 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=selfcare-onboarding-consumer
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=selfcare-onboarding-consumer
 
 CMD node ./jobs/selfcare-onboarding-consumer/dist

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@tsconfig/node-lts": "^18.12.3",
-    "turbo": "^2.0.4",
+    "turbo": "2.0.4",
     "vitest": "0.34.1"
   },
   "packageManager": "pnpm@8.6.12"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@tsconfig/node-lts": "^18.12.3",
-    "turbo": "^1.10.12",
+    "turbo": "^2.0.4",
     "vitest": "0.34.1"
   },
   "packageManager": "pnpm@8.6.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^18.12.3
         version: 18.12.3
       turbo:
-        specifier: ^1.10.12
-        version: 1.10.12
+        specifier: ^2.0.4
+        version: 2.0.4
       vitest:
         specifier: 0.34.1
         version: 0.34.1
@@ -6447,65 +6447,64 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /turbo-darwin-64@1.10.12:
-    resolution: {integrity: sha512-vmDfGVPl5/aFenAbOj3eOx3ePNcWVUyZwYr7taRl0ZBbmv2TzjRiFotO4vrKCiTVnbqjQqAFQWY2ugbqCI1kOQ==}
+  /turbo-darwin-64@2.0.4:
+    resolution: {integrity: sha512-x9mvmh4wudBstML8Z8IOmokLWglIhSfhQwnh2gBCSqabgVBKYvzl8Y+i+UCNPxheCGTgtsPepTcIaKBIyFIcvw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.10.12:
-    resolution: {integrity: sha512-3JliEESLNX2s7g54SOBqqkqJ7UhcOGkS0ywMr5SNuvF6kWVTbuUq7uBU/sVbGq8RwvK1ONlhPvJne5MUqBCTCQ==}
+  /turbo-darwin-arm64@2.0.4:
+    resolution: {integrity: sha512-/B1Ih8zPRGVw5vw4SlclOf3C/woJ/2T6ieH6u54KT4wypoaVyaiyMqBcziIXycdObIYr7jQ+raHO7q3mhay9/A==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.10.12:
-    resolution: {integrity: sha512-siYhgeX0DidIfHSgCR95b8xPee9enKSOjCzx7EjTLmPqPaCiVebRYvbOIYdQWRqiaKh9yfhUtFmtMOMScUf1gg==}
+  /turbo-linux-64@2.0.4:
+    resolution: {integrity: sha512-6aG670e5zOWu6RczEYcB81nEl8EhiGJEvWhUrnAfNEUIMBEH1pR5SsMmG2ol5/m3PgiRM12r13dSqTxCLcHrVg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.10.12:
-    resolution: {integrity: sha512-K/ZhvD9l4SslclaMkTiIrnfcACgos79YcAo4kwc8bnMQaKuUeRpM15sxLpZp3xDjDg8EY93vsKyjaOhdFG2UbA==}
+  /turbo-linux-arm64@2.0.4:
+    resolution: {integrity: sha512-AXfVOjst+mCtPDFT4tCu08Qrfv12Nj7NDd33AjGwV79NYN1Y1rcFY59UQ4nO3ij3rbcvV71Xc+TZJ4csEvRCSg==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.10.12:
-    resolution: {integrity: sha512-7FSgSwvktWDNOqV65l9AbZwcoueAILeE4L7JvjauNASAjjbuzXGCEq5uN8AQU3U5BOFj4TdXrVmO2dX+lLu8Zg==}
+  /turbo-windows-64@2.0.4:
+    resolution: {integrity: sha512-QOnUR9hKl0T5gq5h1fAhVEqBSjpcBi/BbaO71YGQNgsr6pAnCQdbG8/r3MYXet53efM0KTdOhieWeO3KLNKybA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.10.12:
-    resolution: {integrity: sha512-gCNXF52dwom1HLY9ry/cneBPOKTBHhzpqhMylcyvJP0vp9zeMQQkt6yjYv+6QdnmELC92CtKNp2FsNZo+z0pyw==}
+  /turbo-windows-arm64@2.0.4:
+    resolution: {integrity: sha512-3v8WpdZy1AxZw0gha0q3caZmm+0gveBQ40OspD6mxDBIS+oBtO5CkxhIXkFJJW+jDKmDlM7wXDIGfMEq+QyNCQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.10.12:
-    resolution: {integrity: sha512-WM3+jTfQWnB9W208pmP4oeehZcC6JQNlydb/ZHMRrhmQa+htGhWLCzd6Q9rLe0MwZLPpSPFV2/bN5egCLyoKjQ==}
+  /turbo@2.0.4:
+    resolution: {integrity: sha512-Ilme/2Q5kYw0AeRr+aw3s02+WrEYaY7U8vPnqSZU/jaDG/qd6jHVN6nRWyd/9KXvJGYM69vE6JImoGoyNjLwaw==}
     hasBin: true
-    requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.12
-      turbo-darwin-arm64: 1.10.12
-      turbo-linux-64: 1.10.12
-      turbo-linux-arm64: 1.10.12
-      turbo-windows-64: 1.10.12
-      turbo-windows-arm64: 1.10.12
+      turbo-darwin-64: 2.0.4
+      turbo-darwin-arm64: 2.0.4
+      turbo-linux-64: 2.0.4
+      turbo-linux-arm64: 2.0.4
+      turbo-windows-64: 2.0.4
+      turbo-windows-arm64: 2.0.4
     dev: true
 
   /tweetnacl@0.14.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^18.12.3
         version: 18.12.3
       turbo:
-        specifier: ^2.0.4
+        specifier: 2.0.4
         version: 2.0.4
       vitest:
         specifier: 0.34.1

--- a/scripts/create-new-job.mjs
+++ b/scripts/create-new-job.mjs
@@ -168,7 +168,8 @@ RUN apk update
 WORKDIR /app
 RUN corepack enable
 COPY . .
-RUN pnpm --package=turbo dlx turbo prune --scope=${jobName} --docker
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo prune --scope=${jobName} --docker
 
 # remove all empty node_modules folder structure
 RUN rm -rf /app/out/full/*/*/node_modules
@@ -184,11 +185,11 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm dlx turbo run build --filter=${jobName}
+RUN pnpm install --frozen-lockfile
+RUN pnpm turbo run build --filter=${jobName}
 
 CMD node ./jobs/${jobName}/dist
 `

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "start": {
       "persistent": true,
       "cache": false,


### PR DESCRIPTION
This publish CI failing was due to the Dockerfile instructions using the latest turbo version (2.x) while in local the (1.x) was being used.

The fix removes the uses of pnpm's dlx command, which always download and uses the latest version, in favor of always installing and taking the version form the local package.json.
