### PR TITLE
PIN-5024 - Updated `metrics-report-generator` email sender configuration

### DIFF
--- a/jobs/metrics-report-generator/src/configs/env.ts
+++ b/jobs/metrics-report-generator/src/configs/env.ts
@@ -25,6 +25,7 @@ export const Env = z.object({
   SMTP_PASSWORD: z.string(),
   SMTP_SECURE: z.string().transform((value) => value === 'true'),
   MAIL_RECIPIENTS: z.string().transform((value) => value.split(',')),
+  REPORT_SENDER: z.string().email(),
 
   ATHENA_TOKENS_DB_NAME: z.string(),
   ATHENA_OUTPUT_BUCKET: z.string(),

--- a/jobs/metrics-report-generator/src/index.ts
+++ b/jobs/metrics-report-generator/src/index.ts
@@ -78,7 +78,7 @@ const mailer = new Mailer({
 })
 
 await mailer.sendMail({
-  from: env.SMTP_USER,
+  from: env.REPORT_SENDER,
   to: env.MAIL_RECIPIENTS,
   subject: EMAIL_SUBJECT,
   text: EMAIL_TEXT,


### PR DESCRIPTION
Added new `REPORT_SENDER` env variable that specifies the sender of the report data mail